### PR TITLE
Discard master-slave lingo

### DIFF
--- a/env/lib/python3.7/site-packages/django/apps/registry.py
+++ b/env/lib/python3.7/site-packages/django/apps/registry.py
@@ -18,7 +18,7 @@ class Apps:
     """
 
     def __init__(self, installed_apps=()):
-        # installed_apps is set to None when creating the master registry
+        # installed_apps is set to None when creating the main registry
         # because it cannot be populated at that point. Other registries must
         # provide a list of installed apps and are populated immediately.
         if installed_apps is None and hasattr(sys.modules[__name__], 'apps'):
@@ -52,7 +52,7 @@ class Apps:
         # `lazy_model_operation()` and `do_pending_operations()` methods.
         self._pending_operations = defaultdict(list)
 
-        # Populate apps and models, unless it's the master registry.
+        # Populate apps and models, unless it's the main registry.
         if installed_apps is not None:
             self.populate(installed_apps)
 

--- a/env/lib/python3.7/site-packages/django/conf/global_settings.py
+++ b/env/lib/python3.7/site-packages/django/conf/global_settings.py
@@ -215,7 +215,7 @@ FORM_RENDERER = 'django.forms.renderers.DjangoTemplates'
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/env/lib/python3.7/site-packages/django/db/backends/sqlite3/introspection.py
+++ b/env/lib/python3.7/site-packages/django/db/backends/sqlite3/introspection.py
@@ -60,7 +60,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name, type FROM sqlite_master
+            SELECT name, type FROM sqlite_main
             WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [TableInfo(row[0], row[1][0]) for row in cursor.fetchall()]
@@ -97,7 +97,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
         # Schema for this table
         cursor.execute(
-            "SELECT sql, type FROM sqlite_master "
+            "SELECT sql, type FROM sqlite_main "
             "WHERE tbl_name = %s AND type IN ('table', 'view')",
             [table_name]
         )
@@ -127,7 +127,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             else:
                 field_name = field_desc.split()[0].strip('"')
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -153,7 +153,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(') + 1:results.rindex(')')]
 
@@ -178,7 +178,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         """Return the column name of the primary key for the given table."""
         # Don't use PRAGMA because that causes issues with some transactions
         cursor.execute(
-            "SELECT sql, type FROM sqlite_master "
+            "SELECT sql, type FROM sqlite_main "
             "WHERE tbl_name = %s AND type IN ('table', 'view')",
             [table_name]
         )
@@ -255,7 +255,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 # SQLite doesn't support any index type other than b-tree
                 constraints[index]['type'] = Index.suffix
                 cursor.execute(
-                    "SELECT sql FROM sqlite_master "
+                    "SELECT sql FROM sqlite_main "
                     "WHERE type='index' AND name=%s" % self.connection.ops.quote_name(index)
                 )
                 orders = []

--- a/env/lib/python3.7/site-packages/django/db/backends/sqlite3/schema.py
+++ b/env/lib/python3.7/site-packages/django/db/backends/sqlite3/schema.py
@@ -112,15 +112,15 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     new_column_name = new_field.get_attname_column()[1]
                     search = references_template % old_column_name
                     replacement = references_template % new_column_name
-                    cursor.execute('UPDATE sqlite_master SET sql = replace(sql, %s, %s)', (search, replacement))
+                    cursor.execute('UPDATE sqlite_main SET sql = replace(sql, %s, %s)', (search, replacement))
                     cursor.execute('PRAGMA schema_version = %d' % (schema_version + 1))
                     cursor.execute('PRAGMA writable_schema = 0')
                     # The integrity check will raise an exception and rollback
-                    # the transaction if the sqlite_master updates corrupt the
+                    # the transaction if the sqlite_main updates corrupt the
                     # database.
                     cursor.execute('PRAGMA integrity_check')
             # Perform a VACUUM to refresh the database representation from
-            # the sqlite_master table.
+            # the sqlite_main table.
             with self.connection.cursor() as cursor:
                 cursor.execute('VACUUM')
         else:

--- a/env/lib/python3.7/site-packages/django/test/client.py
+++ b/env/lib/python3.7/site-packages/django/test/client.py
@@ -456,7 +456,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Compose the environment dictionary and pass
+        The main request method. Compose the environment dictionary and pass
         to the handler, return the result of the handler. Assume defaults for
         the query environment, which can be overridden using the arguments to
         the request.

--- a/env/lib/python3.7/site-packages/django/test/runner.py
+++ b/env/lib/python3.7/site-packages/django/test/runner.py
@@ -76,7 +76,7 @@ class RemoteTestResult:
     Record information about which tests have succeeded and which have failed.
 
     The sole purpose of this class is to record events in the child processes
-    so they can be replayed in the master process. As a consequence it doesn't
+    so they can be replayed in the main process. As a consequence it doesn't
     inherit unittest.TestResult and doesn't attempt to implement all its API.
 
     The implementation matches the unpythonic coding style of unittest2.

--- a/env/lib/python3.7/site-packages/gunicorn/arbiter.py
+++ b/env/lib/python3.7/site-packages/gunicorn/arbiter.py
@@ -63,8 +63,8 @@ class Arbiter(object):
         self.systemd = False
         self.worker_age = 0
         self.reexec_pid = 0
-        self.master_pid = 0
-        self.master_name = "Master"
+        self.main_pid = 0
+        self.main_name = "Main"
 
         cwd = util.getcwd()
 
@@ -126,14 +126,14 @@ class Arbiter(object):
         self.log.info("Starting gunicorn %s", __version__)
 
         if 'GUNICORN_PID' in os.environ:
-            self.master_pid = int(os.environ.get('GUNICORN_PID'))
+            self.main_pid = int(os.environ.get('GUNICORN_PID'))
             self.proc_name = self.proc_name + ".2"
-            self.master_name = "Master.2"
+            self.main_name = "Main.2"
 
         self.pid = os.getpid()
         if self.cfg.pidfile is not None:
             pidname = self.cfg.pidfile
-            if self.master_pid != 0:
+            if self.main_pid != 0:
                 pidname += ".2"
             self.pidfile = Pidfile(pidname)
             self.pidfile.create(self.pid)
@@ -149,7 +149,7 @@ class Arbiter(object):
                 fds = range(systemd.SD_LISTEN_FDS_START,
                             systemd.SD_LISTEN_FDS_START + listen_fds)
 
-            elif self.master_pid:
+            elif self.main_pid:
                 fds = []
                 for fd in os.environ.pop('GUNICORN_FD').split(','):
                     fds.append(int(fd))
@@ -169,8 +169,8 @@ class Arbiter(object):
 
     def init_signals(self):
         """\
-        Initialize master signal handling. Most of the signals
-        are queued. Child signals only wake up the master.
+        Initialize main signal handling. Most of the signals
+        are queued. Child signals only wake up the main.
         """
         # close old PIPE
         for p in self.PIPE:
@@ -195,15 +195,15 @@ class Arbiter(object):
             self.wakeup()
 
     def run(self):
-        "Main master loop."
+        "Main main loop."
         self.start()
-        util._setproctitle("master [%s]" % self.proc_name)
+        util._setproctitle("main [%s]" % self.proc_name)
 
         try:
             self.manage_workers()
 
             while True:
-                self.maybe_promote_master()
+                self.maybe_promote_main()
 
                 sig = self.SIG_QUEUE.pop(0) if self.SIG_QUEUE else None
                 if sig is None:
@@ -252,7 +252,7 @@ class Arbiter(object):
         - Start the new worker processes with a new configuration
         - Gracefully shutdown the old worker processes
         """
-        self.log.info("Hang up: %s", self.master_name)
+        self.log.info("Hang up: %s", self.main_name)
         self.reload()
 
     def handle_term(self):
@@ -298,8 +298,8 @@ class Arbiter(object):
     def handle_usr2(self):
         """\
         SIGUSR2 handling.
-        Creates a new master/worker set as a slave of the current
-        master without affecting old workers. Use this to do live
+        Creates a new main/worker set as a subordinate of the current
+        main without affecting old workers. Use this to do live
         deployment with the ability to backout a change.
         """
         self.reexec()
@@ -313,22 +313,22 @@ class Arbiter(object):
         else:
             self.log.debug("SIGWINCH ignored. Not daemonized")
 
-    def maybe_promote_master(self):
-        if self.master_pid == 0:
+    def maybe_promote_main(self):
+        if self.main_pid == 0:
             return
 
-        if self.master_pid != os.getppid():
-            self.log.info("Master has been promoted.")
-            # reset master infos
-            self.master_name = "Master"
-            self.master_pid = 0
+        if self.main_pid != os.getppid():
+            self.log.info("Main has been promoted.")
+            # reset main infos
+            self.main_name = "Main"
+            self.main_pid = 0
             self.proc_name = self.cfg.proc_name
             del os.environ['GUNICORN_PID']
             # rename the pidfile
             if self.pidfile is not None:
                 self.pidfile.rename(self.cfg.pidfile)
             # reset proctitle
-            util._setproctitle("master [%s]" % self.proc_name)
+            util._setproctitle("main [%s]" % self.proc_name)
 
     def wakeup(self):
         """\
@@ -343,7 +343,7 @@ class Arbiter(object):
     def halt(self, reason=None, exit_status=0):
         """ halt arbiter """
         self.stop()
-        self.log.info("Shutting down: %s", self.master_name)
+        self.log.info("Shutting down: %s", self.main_name)
         if reason is not None:
             self.log.info("Reason: %s", reason)
         if self.pidfile is not None:
@@ -378,7 +378,7 @@ class Arbiter(object):
         killed gracefully  (ie. trying to wait for the current connection)
         """
 
-        unlink = self.reexec_pid == self.master_pid == 0 and not self.systemd
+        unlink = self.reexec_pid == self.main_pid == 0 and not self.systemd
         sock.close_sockets(self.LISTENERS, unlink)
 
         self.LISTENERS = []
@@ -396,17 +396,17 @@ class Arbiter(object):
 
     def reexec(self):
         """\
-        Relaunch the master and workers.
+        Relaunch the main and workers.
         """
         if self.reexec_pid != 0:
             self.log.warning("USR2 signal ignored. Child exists.")
             return
 
-        if self.master_pid != 0:
+        if self.main_pid != 0:
             self.log.warning("USR2 signal ignored. Parent exists.")
             return
 
-        master_pid = os.getpid()
+        main_pid = os.getpid()
         self.reexec_pid = os.fork()
         if self.reexec_pid != 0:
             return
@@ -414,7 +414,7 @@ class Arbiter(object):
         self.cfg.pre_exec(self)
 
         environ = self.cfg.env_orig.copy()
-        environ['GUNICORN_PID'] = str(master_pid)
+        environ['GUNICORN_PID'] = str(main_pid)
 
         if self.systemd:
             environ['LISTEN_PID'] = str(os.getpid())
@@ -474,7 +474,7 @@ class Arbiter(object):
             self.pidfile.create(self.pid)
 
         # set new proc_name
-        util._setproctitle("master [%s]" % self.proc_name)
+        util._setproctitle("main [%s]" % self.proc_name)
 
         # spawn new workers
         for _ in range(self.cfg.workers):
@@ -609,7 +609,7 @@ class Arbiter(object):
         Spawn new workers as needed.
 
         This is where a worker process leaves the main loop
-        of the master process.
+        of the main process.
         """
 
         for _ in range(self.num_workers - len(self.WORKERS.keys())):

--- a/env/lib/python3.7/site-packages/gunicorn/config.py
+++ b/env/lib/python3.7/site-packages/gunicorn/config.py
@@ -1546,7 +1546,7 @@ class OnStarting(Setting):
         pass
     default = staticmethod(on_starting)
     desc = """\
-        Called just before the master process is initialized.
+        Called just before the main process is initialized.
 
         The callable needs to accept a single instance variable for the Arbiter.
         """
@@ -1683,7 +1683,7 @@ class PreExec(Setting):
         pass
     default = staticmethod(pre_exec)
     desc = """\
-        Called just before a new master process is forked.
+        Called just before a new main process is forked.
 
         The callable needs to accept a single instance variable for the Arbiter.
         """
@@ -1733,7 +1733,7 @@ class ChildExit(Setting):
         pass
     default = staticmethod(child_exit)
     desc = """\
-        Called just after a worker has been exited, in the master process.
+        Called just after a worker has been exited, in the main process.
 
         The callable needs to accept two instance variables for the Arbiter and
         the just-exited Worker.

--- a/env/lib/python3.7/site-packages/gunicorn/workers/base.py
+++ b/env/lib/python3.7/site-packages/gunicorn/workers/base.py
@@ -64,7 +64,7 @@ class Worker(object):
         """\
         Your worker subclass must arrange to have this method called
         once every ``self.timeout`` seconds. If you fail in accomplishing
-        this task, the master process will murder your workers.
+        this task, the main process will murder your workers.
         """
         self.tmp.notify()
 

--- a/env/lib/python3.7/site-packages/pip/_internal/vcs/git.py
+++ b/env/lib/python3.7/site-packages/pip/_internal/vcs/git.py
@@ -196,7 +196,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         rev_options = self.check_rev_options(dest, rev_options)
         cmd_args = ['reset', '--hard', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)

--- a/env/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py
+++ b/env/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py
@@ -554,9 +554,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3093,9 +3093,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3105,7 +3105,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/env/lib/python3.7/site-packages/pkg_resources/__init__.py
+++ b/env/lib/python3.7/site-packages/pkg_resources/__init__.py
@@ -558,9 +558,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3086,9 +3086,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3098,7 +3098,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/env/lib/python3.7/site-packages/psycopg2/tests/test_connection.py
+++ b/env/lib/python3.7/site-packages/psycopg2/tests/test_connection.py
@@ -208,15 +208,15 @@ class ConnectionTests(ConnectingTestCase):
     @slow
     @skip_before_postgres(8, 2)
     def test_concurrent_execution(self):
-        def slave():
+        def subordinate():
             cnn = self.connect()
             cur = cnn.cursor()
             cur.execute("select pg_sleep(4)")
             cur.close()
             cnn.close()
 
-        t1 = threading.Thread(target=slave)
-        t2 = threading.Thread(target=slave)
+        t1 = threading.Thread(target=subordinate)
+        t2 = threading.Thread(target=subordinate)
         t0 = time.time()
         t1.start()
         t2.start()

--- a/env/lib/python3.7/site-packages/setuptools/command/easy_install.py
+++ b/env/lib/python3.7/site-packages/setuptools/command/easy_install.py
@@ -1775,7 +1775,7 @@ def update_dist_caches(dist_path, fix_zipimporter_caches):
     # There are several other known sources of stale zipimport.zipimporter
     # instances that we do not clear here, but might if ever given a reason to
     # do so:
-    # * Global setuptools pkg_resources.working_set (a.k.a. 'master working
+    # * Global setuptools pkg_resources.working_set (a.k.a. 'main working
     # set') may contain distributions which may in turn contain their
     #   zipimport.zipimporter loaders.
     # * Several zipimport.zipimporter loaders held by local variables further

--- a/jinromura/migrations/0001_initial.py
+++ b/jinromura/migrations/0001_initial.py
@@ -52,7 +52,7 @@ class Migration(migrations.Migration):
                 ('zombi', models.IntegerField(default=0)),
                 ('teruteru', models.IntegerField(default=0)),
                 ('wiseman', models.IntegerField(default=0)),
-                ('slave', models.IntegerField(default=0)),
+                ('subordinate', models.IntegerField(default=0)),
                 ('aristcracy', models.IntegerField(default=0)),
                 ('wolfboy', models.IntegerField(default=0)),
                 ('santa', models.IntegerField(default=0)),

--- a/jinromura/migrations/0007_auto_20180923_0417.py
+++ b/jinromura/migrations/0007_auto_20180923_0417.py
@@ -187,7 +187,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterField(
             model_name='village',
-            name='slave',
+            name='subordinate',
             field=models.IntegerField(default=0, verbose_name='奴隷'),
         ),
         migrations.AlterField(

--- a/jinromura/models.py
+++ b/jinromura/models.py
@@ -29,7 +29,7 @@ class Village(models.Model):
     zombi = models.IntegerField('ゾンビ',default=0)
     teruteru = models.IntegerField('てるてる坊主',default=0)
     wiseman = models.IntegerField('賢者',default=0)
-    slave = models.IntegerField('奴隷',default=0)
+    subordinate = models.IntegerField('奴隷',default=0)
     aristcracy = models.IntegerField('貴族',default=0)
     wolfboy = models.IntegerField('狼少年',default=0)
     santa = models.IntegerField('サンタ',default=0)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.